### PR TITLE
Add GitHub Actions for linting, testing, and publishing IDConn

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,55 @@
+name: "Lint Code"
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - '*'
+
+concurrency:
+  group: linting-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Determine if tests should be run based on commit message.
+  check_skip:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.result_step.outputs.ci-skip }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - id: result_step
+        uses: mstachniuk/ci-skip@master
+        with:
+          commit-filter: '[skip ci];[ci skip];[skip github]'
+          commit-filter-separator: ';'
+
+  style_check:
+    needs: check_skip
+    if: ${{ needs.check_skip.outputs.skip == 'false' }}
+    runs-on: "ubuntu-latest"
+    strategy:
+        fail-fast: false
+        matrix:
+            os: ["ubuntu-latest"]
+            python-version: ["3.7"]
+    name: Style check
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Set up python'
+        uses: actions/setup-python@v2
+        with:
+            python-version: ${{ matrix.python-version }}
+      - name: 'Install IDConn'
+        shell: bash {0}
+        run: pip install -e .[tests]
+      - name: 'Run linter'
+        shell: bash {0}
+        run: make lint

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -52,4 +52,4 @@ jobs:
         run: pip install -e .[tests]
       - name: 'Run linter'
         shell: bash {0}
-        run: make lint
+        run: flake8 idconn

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,31 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,76 @@
+name: "Run Tests"
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - '*'
+
+concurrency:
+  group: testing-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Determine if tests should be run based on commit message.
+  check_skip:
+    name: Determine if CI should be skipped
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.result_step.outputs.ci-skip }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - id: result_step
+        uses: mstachniuk/ci-skip@master
+        with:
+          commit-filter: '[skip ci];[ci skip];[skip github]'
+          commit-filter-separator: ';'
+
+  run_unit_tests:
+    name: Unit tests
+    needs: check_skip
+    if: ${{ needs.check_skip.outputs.skip == 'false' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+        fail-fast: false
+        matrix:
+            os: ["ubuntu-latest", "macos-latest"]
+            python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Set up python'
+        uses: actions/setup-python@v2
+        with:
+            python-version: ${{ matrix.python-version }}
+      - name: 'Install IDConn'
+        shell: bash {0}
+        run: pip install -e .[tests]
+      - name: 'Run tests'
+        shell: bash {0}
+        run: py.test --cov-append --cov-report=xml --cov=idconn idconn
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: unit_${{ matrix.os }}_${{ matrix.python-version }}
+          path: coverage.xml
+        if: success()
+
+  upload_to_codecov:
+    name: Upload coverage
+    needs: [run_unit_tests]
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+      - name: Upload to CodeCov
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true

--- a/idconn/tests/test_pipeline.py
+++ b/idconn/tests/test_pipeline.py
@@ -1,0 +1,8 @@
+"""Tests for idconn.pipeline."""
+
+
+def test_idconn_workflow_smoke():
+    from idconn.pipeline import idconn_workflow
+
+    # Check that it's a function ¯\_(ツ)_/¯
+    assert callable(idconn_workflow)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==40.8", "wheel"]
+requires = ["setuptools==58.2.0", "wheel"]
 
 [tool.black]
 line-length = 99

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,18 @@ setuptools.setup(
         "networkx",
         "matplotlib",  # necessary until nilearn includes mpl as a dependency
     ],
+    extra_requires={
+        "tests": [
+            "codecov",
+            "coverage",
+            "coveralls",
+            "flake8-black",
+            "flake8-docstrings",
+            "flake8-isort",
+            "pytest",
+            "pytest-cov",
+        ],
+    },
     entry_points={
         "console_scripts": [
             "idconn=idconn.pipeline:_main",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
         "networkx",
         "matplotlib",  # necessary until nilearn includes mpl as a dependency
     ],
-    extra_requires={
+    extras_require={
         "tests": [
             "codecov",
             "coverage",


### PR DESCRIPTION
The new actions will run flake8 and pytest on PRs, and will publish IDConn to PyPi, though there are additional steps before that will work.

To get IDConn uploading to PyPi when GitHub releases are made, you need to do the following:
1. Add new secrets to the repository, PYPI_PASSWORD and PYPI_USERNAME, with your PyPi password and username, respectively. Alternatively, you could use a token.
2. Upload one release manually (e.g., by following [these instructions](https://realpython.com/pypi-publish-python-package/)). It seems like the Action will only work on an existing project.